### PR TITLE
Catch up API breaking change of ActivityService.ListStarred().

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,14 +23,14 @@ func main() {
 	for page := 1; ; page++ {
 		options.Page = page
 
-		repositories, res, err := client.Activity.ListStarred(user, options)
+		starredRepos, res, err := client.Activity.ListStarred(user, options)
 		if err != nil {
 			log.Fatalf("ListStarred: %s", err)
 		}
 
 		log.Printf("page: %d/%d", page, res.LastPage)
-		for _, repo := range repositories {
-			fmt.Println(*repo.HTMLURL)
+		for _, starredRepo := range starredRepos {
+			fmt.Println(*starredRepo.Repository.HTMLURL)
 		}
 
 		if page >= res.LastPage {


### PR DESCRIPTION
[ActivityService.ListStarred()](https://godoc.org/github.com/google/go-github/github#ActivityService.ListStarred) returns `type StarredRepository` which contains `type Repository` as field named `Repository` since [this commit](https://github.com/google/go-github/commit/fbc5be653cbec079531d26037d4872fe3ca4395f).
