### PR TITLE
Catch up API breaking change of ActivityService.ListStarred().

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	for page := 1; ; page++ {
 		options.Page = page
 
-		starredRepos, res, err := client.Activity.ListStarred(user, options)
+		starredRepos, res, err := client.Activity.ListStarred(context.Background(), user, options)
 		if err != nil {
 			log.Fatalf("ListStarred: %s", err)
 		}


### PR DESCRIPTION
[`ActivityService.ListStarred()`](https://godoc.org/github.com/google/go-github/github#ActivityService.ListStarred) needs `ctx context.Context` as 1st parameter [since this commit](https://github.com/google/go-github/commit/23d6cb9cacb5aa314e93d600fe20a48496a718d4).